### PR TITLE
Fix antmicro-yosys installation

### DIFF
--- a/syn/antmicro-yosys/build.sh
+++ b/syn/antmicro-yosys/build.sh
@@ -9,7 +9,14 @@ cd yosys
 
 make V=1 -j$CPU_COUNT
 make install V=1 -j$CPU_COUNT
-cp yosys "$PREFIX/bin/antmicro-yosys"
-cp yosys-config "$PREFIX/bin/yosys-config"
+
+pushd $PREFIX/bin
+
+for filename in `ls yosys*`;
+do
+    mv $filename "antmicro-"$filename
+done
+
+popd
 
 $PREFIX/bin/antmicro-yosys -V


### PR DESCRIPTION
The build scripts in the previous version were installing yosys binaries with the original names. It was causing conflicts with the original yosys package.
Now all the binaries from this package will use the "antmicro-" prefix, so there won't be any conflicts.